### PR TITLE
show assigned essay on overview

### DIFF
--- a/src/Demo/Utils/checking-functions.js
+++ b/src/Demo/Utils/checking-functions.js
@@ -1655,7 +1655,12 @@ const prepEssayTask = (essay, user) => {
                 : is_TaiGer_Agent(user)
                   ? essay.student_id?.agents.some(
                         (agent) => agent._id.toString() === user._id.toString()
-                    ) || false
+                    ) ||
+                    essay.outsourced_user_id?.some(
+                        (outsourcer) =>
+                            outsourcer._id.toString() === user._id.toString()
+                    ) ||
+                    false
                   : true,
         document_name: `${essay.file_type} - ${essay.program_id.school} - ${essay.program_id.degree} -${essay.program_id.program_name}`,
         days_left:


### PR DESCRIPTION
## Changes
- Modified the `prepEssayTask` function in `checking-functions.js` to allow agents to view essays where they are listed in `outsourced_user_id`
- Previously, agents could only view essays for students they were assigned to
- Now agents can view essays in two cases:
  1. When they are assigned to the student (existing behavior)
  2. When they are listed as an outsourced user in the essay (new behavior)