### PR TITLE
add count to shoe assign editor row in admin view

### DIFF
--- a/src/Demo/Dashboard/MainViewTab/Common/AssignEditorRow.js
+++ b/src/Demo/Dashboard/MainViewTab/Common/AssignEditorRow.js
@@ -3,14 +3,18 @@ import { Link as LinkDom } from 'react-router-dom';
 import { t } from 'i18next';
 
 import DEMO from '../../../../store/constant';
-import { does_student_have_editors } from '../../../Utils/checking-functions';
+import { getStudentEditorStatus } from '../../../Utils/checking-functions';
 
 const AssignEditorRow = (props) => {
-    return !does_student_have_editors(props.students) ? (
+    const { allHaveEditors, countWithoutEditors } = getStudentEditorStatus(
+        props.students
+    );
+    return !allHaveEditors ? (
         <TableRow>
             <TableCell>
                 <Link component={LinkDom} to={`${DEMO.ASSIGN_EDITOR_LINK}`}>
-                    {t('Assign Editors')}
+                    {t('Assign Editors', { ns: 'common' })} (
+                    {countWithoutEditors})
                 </Link>
             </TableCell>
             <TableCell>

--- a/src/Demo/Utils/checking-functions.js
+++ b/src/Demo/Utils/checking-functions.js
@@ -873,10 +873,23 @@ export const does_student_have_agents = (students) => {
     );
 };
 
-export const does_student_have_editors = (students) => {
-    return students.every(
-        (student) => student.editors !== undefined && student.editors.length > 0
+export const getStudentEditorStatus = (students) => {
+    const studentsWithoutEditors = students.filter(
+        (student) => !student.editors || student.editors.length === 0
     );
+    return {
+        allHaveEditors: studentsWithoutEditors.length === 0,
+        countWithoutEditors: studentsWithoutEditors.length
+    };
+};
+
+// For backward compatibility
+export const does_student_have_editors = (students) => {
+    return getStudentEditorStatus(students).allHaveEditors;
+};
+
+export const number_of_students_without_editors = (students) => {
+    return getStudentEditorStatus(students).countWithoutEditors;
 };
 
 export const check_applications_to_decided = (student) => {


### PR DESCRIPTION
## Changes Made
- Added a count display to the "Assign Editors" row in the dashboard to show the number of students without editors
- Refactored editor-related checking functions for better performance and maintainability
- Maintained backward compatibility with existing code

## Technical Details
- Created a new `getStudentEditorStatus` function that returns both the boolean check and count in a single pass
- Updated `AssignEditorRow` component to display the count of students without editors
- Kept existing function names for backward compatibility

manual test overview
<img width="672" alt="Screenshot 2025-04-06 at 10 54 13" src="https://github.com/user-attachments/assets/5e1e7a13-35f8-4d7c-b182-4c02d83ecf73" />
<img width="515" alt="Screenshot 2025-04-06 at 10 54 07" src="https://github.com/user-attachments/assets/a3f96684-49fe-4719-802e-f202b3476152" />
<img width="657" alt="Screenshot 2025-04-06 at 10 53 46" src="https://github.com/user-attachments/assets/0cf0d47d-37aa-47f4-bc14-6078b7b92b50" />
<img width="534" alt="Screenshot 2025-04-06 at 10 53 37" src="https://github.com/user-attachments/assets/9a9f6c2f-7450-4914-af83-54d242d25120" />
