### PR TITLE
Feat add interveiw survey status

### DIFF
--- a/src/Demo/InterviewTraining/index.js
+++ b/src/Demo/InterviewTraining/index.js
@@ -19,6 +19,11 @@ import { appConfig } from '../../config';
 import { convertDate, showTimezoneOffset } from '../../utils/contants';
 import { InterviewsTable } from './InterviewsTable';
 
+import {
+    CheckCircle as CheckCircleIcon,
+    Error as ErrorIcon
+} from '@mui/icons-material';
+
 const InterviewTraining = () => {
     const { user } = useAuth();
     const { t } = useTranslation();
@@ -141,6 +146,26 @@ const InterviewTraining = () => {
             filterVariant: 'multi-select',
             header: t('Status', { ns: 'common' }),
             width: 100
+        },
+        {
+            accessorKey: 'surveySubmitted',
+            filterVariant: 'select',
+            filterSelectOptions: [
+                { value: true, label: t('Yes', { ns: 'common' }) },
+                { value: false, label: t('No', { ns: 'common' }) }
+            ],
+            filterFn: (row, id, filterValue) => {
+                // filterValue is boolean true/false
+                return row.getValue(id) === filterValue;
+            },
+            header: t('Survey', { ns: 'common' }),
+            width: 50,
+            Cell: ({ cell }) =>
+                cell.getValue() ? (
+                    <CheckCircleIcon color="success" />
+                ) : (
+                    <ErrorIcon color="error" />
+                )
         },
         {
             accessorKey: 'firstname_lastname',

--- a/src/Demo/InterviewTraining/index.js
+++ b/src/Demo/InterviewTraining/index.js
@@ -145,21 +145,13 @@ const InterviewTraining = () => {
             accessorKey: 'status',
             filterVariant: 'multi-select',
             header: t('Status', { ns: 'common' }),
-            width: 100
+            size: 180
         },
         {
             accessorKey: 'surveySubmitted',
-            filterVariant: 'select',
-            filterSelectOptions: [
-                { value: true, label: t('Yes', { ns: 'common' }) },
-                { value: false, label: t('No', { ns: 'common' }) }
-            ],
-            filterFn: (row, id, filterValue) => {
-                // filterValue is boolean true/false
-                return row.getValue(id) === filterValue;
-            },
+            enableColumnFilter: false,
             header: t('Survey', { ns: 'common' }),
-            width: 50,
+            size: 110,
             Cell: ({ cell }) =>
                 cell.getValue() ? (
                     <CheckCircleIcon color="success" />
@@ -193,7 +185,7 @@ const InterviewTraining = () => {
         {
             accessorKey: 'trainer_name',
             header: t('Trainer', { ns: 'common' }),
-            size: 100
+            size: 150
         },
         {
             accessorKey: 'start',
@@ -203,7 +195,7 @@ const InterviewTraining = () => {
             align: 'left',
             headerAlign: 'left',
             filterFn: 'contains',
-            width: 250,
+            size: 280,
             Cell: (params) => {
                 const { row } = params;
                 return row.original.start;
@@ -215,7 +207,7 @@ const InterviewTraining = () => {
             align: 'left',
             headerAlign: 'left',
             filterFn: 'contains',
-            width: 100,
+            size: 220,
             Cell: (params) => {
                 const { row } = params;
                 return row.original.interview_date;


### PR DESCRIPTION
This pull request introduces updates to the `InterviewTraining` component in `src/Demo/InterviewTraining/index.js`, key changes include the addition of a new column for survey status with visual indicators.

![image](https://github.com/user-attachments/assets/58377929-d1e4-4ffc-89db-7a060443f966)

Dependent on backend changes: https://github.com/LIYUNG/TaiGerPortalService/pull/87
