### PR TITLE
fix radion group response in interviewExperienceStep

### DIFF
--- a/src/Demo/InterviewTraining/InterviewSurveyForm.js
+++ b/src/Demo/InterviewTraining/InterviewSurveyForm.js
@@ -101,17 +101,27 @@ const InterviewSurveyForm = () => {
                     result
                 );
 
+                // Map questionsAnswered numeric values back to strings
+                const questionsAnsweredReverseMap = {
+                    1: 'yes',
+                    2: 'mostly',
+                    3: 'some',
+                    4: 'no'
+                };
+
                 // Map the old field names to new field names
                 const mappedValues = {
                     interviewRating: result.q1 || '',
                     informationClarity: result.q2 || '',
                     trainerFriendliness: result.q3 || '',
-                    questionsAnswered: result.questionsAnswered || '',
+                    questionsAnswered:
+                        questionsAnsweredReverseMap[result.questionsAnswered] ||
+                        '',
                     preparationHelp: data?.interviewQuestions || '',
                     overallExperience: data?.interviewFeedback || '',
                     improvements: result.improvements || '',
                     additionalComments: result.additionalComments || '',
-                    isFinal: true
+                    isFinal: data?.isFinal || false
                 };
 
                 console.log('mappedValues:', mappedValues);
@@ -149,6 +159,15 @@ const InterviewSurveyForm = () => {
     const handleSaveDraft = async () => {
         try {
             setIsChanged(false);
+
+            // Map questionsAnswered string values to numbers
+            const questionsAnsweredMap = {
+                yes: 1,
+                mostly: 2,
+                some: 3,
+                no: 4
+            };
+
             const response = await updateInterviewSurvey(interview_id, {
                 student_id: interview.student_id?._id?.toString(),
                 interview_id: interview_id,
@@ -167,7 +186,8 @@ const InterviewSurveyForm = () => {
                     },
                     {
                         questionId: 'questionsAnswered',
-                        answer: Number(values.questionsAnswered)
+                        answer:
+                            questionsAnsweredMap[values.questionsAnswered] || 0
                     }
                 ],
                 interviewQuestions: values.preparationHelp,
@@ -182,6 +202,15 @@ const InterviewSurveyForm = () => {
     const handleSubmit = async () => {
         try {
             setIsLoading(true);
+
+            // Map questionsAnswered string values to numbers
+            const questionsAnsweredMap = {
+                yes: 1,
+                mostly: 2,
+                some: 3,
+                no: 4
+            };
+
             const response = await updateInterviewSurvey(interview_id, {
                 student_id: interview.student_id?._id?.toString(),
                 interview_id: interview_id,
@@ -200,7 +229,8 @@ const InterviewSurveyForm = () => {
                     },
                     {
                         questionId: 'questionsAnswered',
-                        answer: Number(values.questionsAnswered)
+                        answer:
+                            questionsAnsweredMap[values.questionsAnswered] || 0
                     }
                 ],
                 isFinal: true,


### PR DESCRIPTION
**Overview**
This PR fixes a critical issue where radio group responses in the Interview Survey Form were not being saved properly due to a data type mismatch between the frontend (string values) and backend (numeric requirements).

**Problem Description**
The questionsAnswered radio group in the Interview Experience step uses string values ('yes', 'mostly', 'some', 'no'), but the backend API expects all responses in the responses array to have numeric answer values. When the code attempted to convert these strings to numbers using Number('yes'), it returned NaN, causing cast errors and preventing the survey from being saved.

Error Details:
Frontend Values: 'yes', 'mostly', 'some', 'no'
Backend Expectation: answer: Number
Result: Number('yes') → NaN → Cast Error

**Solution**
Implemented a bidirectional mapping system to convert between string values (UI) and numeric values (API):
1. String to Number Mapping (Save Operations)
2. Number to String Mapping (Load Operations)

**Changes Made**

Files Modified:
TaiGerPortalStaticWebsite/src/Demo/InterviewTraining/InterviewSurveyForm.js

Functions Updated:
1. handleSaveDraft()
Before: answer: Number(values.questionsAnswered) → NaN
After: answer: questionsAnsweredMap[values.questionsAnswered] || 0

2. handleSubmit()
Before: answer: Number(values.questionsAnswered) → NaN
After: answer: questionsAnsweredMap[values.questionsAnswered] || 0

4. fetchInterviewAndSurvey()
Before: questionsAnswered: result.questionsAnswered || ''
After: questionsAnswered: questionsAnsweredReverseMap[result.questionsAnswered] || ''

to conclude: 
response from Were all your questions answered satisfactorily? * didn't save correctly
<img width="921" alt="Screenshot 2025-07-06 at 5 10 17 PM" src="https://github.com/user-attachments/assets/382fd5ed-0164-4c9f-95c1-aee80d62238b" />
