### PR TITLE
remove redundant interview survey question

### DIFF
--- a/src/components/SurveyProvider/InterviewExperienceStep.js
+++ b/src/components/SurveyProvider/InterviewExperienceStep.js
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-    Box,
-    Typography,
-    Divider,
-    RadioGroup,
-    FormControlLabel,
-    Radio
-} from '@mui/material';
+import { Box, Typography, Divider } from '@mui/material';
 import StarRating from './StarRating';
 
 const InterviewExperienceStep = ({ values, onChange, disabled }) => (
@@ -84,39 +77,6 @@ const InterviewExperienceStep = ({ values, onChange, disabled }) => (
                 }}
                 rating={values.trainerFriendliness}
             />
-        </Box>
-
-        <Box>
-            <Typography sx={{ mb: 1 }} variant="subtitle2">
-                Were all your questions answered satisfactorily?{' '}
-                <span style={{ color: '#ef4444' }}>*</span>
-            </Typography>
-            <RadioGroup
-                name="questionsAnswered"
-                onChange={onChange}
-                value={values.questionsAnswered || ''}
-            >
-                {[
-                    { value: 'yes', label: 'Yes, all questions were answered' },
-                    { value: 'mostly', label: 'Most questions were answered' },
-                    {
-                        value: 'some',
-                        label: 'Some questions remained unanswered'
-                    },
-                    {
-                        value: 'no',
-                        label: 'No, many questions were left unanswered'
-                    }
-                ].map((option) => (
-                    <FormControlLabel
-                        control={<Radio />}
-                        disabled={disabled}
-                        key={option.value}
-                        label={option.label}
-                        value={option.value}
-                    />
-                ))}
-            </RadioGroup>
         </Box>
     </Box>
 );


### PR DESCRIPTION
remove section 
`were all your questions answered satisfactorily?`

hide box on frontend, backend is still compatible

<img width="2562" height="1716" alt="Screenshot 2025-08-20 at 16 07 50" src="https://github.com/user-attachments/assets/9427dec2-0f8d-4903-abd9-e0f3511a1137" />
<img width="1228" height="885" alt="Screenshot 2025-08-20 at 4 45 03 PM" src="https://github.com/user-attachments/assets/c8fbf82c-9150-46f1-801e-f9be92972484" />
