### PR TITLE
Implement post-login redirect handling and sanitize OAuth paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
     RouterProvider,
     createBrowserRouter,
     useNavigation,
+    useLocation,
     type RouteObject
 } from 'react-router-dom';
 import '@fontsource/roboto';
@@ -19,6 +20,7 @@ import DEMO from '@store/constant';
 import { useAuth } from '@components/AuthProvider';
 import Loading from '@components/Loading/Loading';
 import { ChunkLoadErrorBoundary } from '@utils/chunkLoadError';
+import { getPostLoginRedirectPath } from '@utils/authRedirect';
 
 const Layout = (): JSX.Element => {
     const navigation = useNavigation();
@@ -45,10 +47,19 @@ const Layout = (): JSX.Element => {
 const WrapperPublic = (): JSX.Element => {
     const { isAuthenticated } = useAuth();
     const query = new URLSearchParams(window.location.search);
+    const redirectPath = getPostLoginRedirectPath(query);
+    const location = useLocation();
+    const isOAuthCallback = location.pathname === '/account/google/verify';
 
     return isAuthenticated ? (
-        query.get('p') ? (
-            <Navigate to={query.get('p') ?? '/'} />
+        isOAuthCallback ? (
+            <ChunkLoadErrorBoundary>
+                <Suspense fallback={<Loading />}>
+                    <Outlet />
+                </Suspense>
+            </ChunkLoadErrorBoundary>
+        ) : redirectPath ? (
+            <Navigate to={redirectPath} />
         ) : (
             <Navigate to={DEMO.DASHBOARD_LINK} />
         )

--- a/src/components/Buttons/GoolgeSignInButton.tsx
+++ b/src/components/Buttons/GoolgeSignInButton.tsx
@@ -1,25 +1,10 @@
 import { Button, SvgIcon } from '@mui/material';
 import { googleOAuthClientId, googleOAuthRedirectUrl } from '../../env';
 import DEMO from '@store/constant';
+import { sanitizeInternalPath } from '@utils/authRedirect';
 
 const GOOGLE_OAUTH_CLIENT_ID = googleOAuthClientId;
 const GOOGLE_OAUTH_REDIRECT_URL = googleOAuthRedirectUrl;
-
-const sanitizeInternalPath = (value: string | null): string | null => {
-    if (!value) {
-        return null;
-    }
-
-    if (
-        !value.startsWith('/') ||
-        value.startsWith('//') ||
-        value.includes('://')
-    ) {
-        return null;
-    }
-
-    return value;
-};
 
 function GoogleIcon(): JSX.Element {
     return (

--- a/src/components/Buttons/GoolgeSignInButton.tsx
+++ b/src/components/Buttons/GoolgeSignInButton.tsx
@@ -1,8 +1,25 @@
 import { Button, SvgIcon } from '@mui/material';
 import { googleOAuthClientId, googleOAuthRedirectUrl } from '../../env';
+import DEMO from '@store/constant';
 
 const GOOGLE_OAUTH_CLIENT_ID = googleOAuthClientId;
 const GOOGLE_OAUTH_REDIRECT_URL = googleOAuthRedirectUrl;
+
+const sanitizeInternalPath = (value: string | null): string | null => {
+    if (!value) {
+        return null;
+    }
+
+    if (
+        !value.startsWith('/') ||
+        value.startsWith('//') ||
+        value.includes('://')
+    ) {
+        return null;
+    }
+
+    return value;
+};
 
 function GoogleIcon(): JSX.Element {
     return (
@@ -38,12 +55,15 @@ function GoogleIcon(): JSX.Element {
 export const GoogleLoginButton = (): JSX.Element => {
     const handleGoogleLogin = (): void => {
         const url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+        const loginUrl = new URL(window.location.href);
+        const returnTo = sanitizeInternalPath(loginUrl.searchParams.get('p'));
 
         const query = new URLSearchParams({
             client_id: GOOGLE_OAUTH_CLIENT_ID ?? '',
             redirect_uri: GOOGLE_OAUTH_REDIRECT_URL ?? '',
             response_type: 'code',
-            scope: 'openid email profile'
+            scope: 'openid email profile',
+            state: returnTo ?? DEMO.DASHBOARD_LINK
         });
         url.search = query.toString();
 

--- a/src/pages/Authentication/GoogleOauthCallback/index.tsx
+++ b/src/pages/Authentication/GoogleOauthCallback/index.tsx
@@ -15,6 +15,7 @@ import DEMO from '@store/constant';
 import AuthWrapper from '@components/AuthWrapper';
 import { t } from 'i18next';
 import { ApiResponse, IUserWithId } from '@taiger-common/model';
+import { getPostLoginRedirectPath } from '@utils/authRedirect';
 
 export default function GoogleOAuthCallback() {
     const [searchParams] = useSearchParams();
@@ -32,8 +33,8 @@ export default function GoogleOAuthCallback() {
             // Extract data from response (assuming it's an AxiosResponse)
             const responseData = response;
             login(responseData.data!);
-            // Redirect to dashboard or home page
-            navigate(DEMO.DASHBOARD_LINK, { replace: true });
+            const returnTo = getPostLoginRedirectPath(searchParams);
+            navigate(returnTo ?? DEMO.DASHBOARD_LINK, { replace: true });
         },
         onError: (error) => {
             console.error('OAuth failed:', error);

--- a/src/utils/authRedirect.test.ts
+++ b/src/utils/authRedirect.test.ts
@@ -35,4 +35,9 @@ describe('authRedirect', () => {
             '/admissions-overview'
         );
     });
+
+    it('rejects paths containing backslashes', () => {
+        expect(sanitizeInternalPath('/some\\path')).toBeNull();
+        expect(sanitizeInternalPath('some\\path')).toBeNull();
+    });
 });

--- a/src/utils/authRedirect.test.ts
+++ b/src/utils/authRedirect.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { getPostLoginRedirectPath, sanitizeInternalPath } from './authRedirect';
+
+describe('authRedirect', () => {
+    it('prefers state over p for post-login redirects', () => {
+        const searchParams = new URLSearchParams(
+            '?p=/admissions-overview&state=/account/profile'
+        );
+
+        expect(getPostLoginRedirectPath(searchParams)).toBe('/account/profile');
+    });
+
+    it('falls back to p when state is missing', () => {
+        const searchParams = new URLSearchParams('?p=/admissions-overview');
+
+        expect(getPostLoginRedirectPath(searchParams)).toBe(
+            '/admissions-overview'
+        );
+    });
+
+    it('normalizes relative internal paths by adding a leading slash', () => {
+        const searchParams = new URLSearchParams(
+            '?state=programs/2532fde46751651537901408'
+        );
+
+        expect(getPostLoginRedirectPath(searchParams)).toBe(
+            '/programs/2532fde46751651537901408'
+        );
+    });
+
+    it('rejects unsafe internal paths', () => {
+        expect(sanitizeInternalPath('https://example.com')).toBeNull();
+        expect(sanitizeInternalPath('//example.com')).toBeNull();
+        expect(sanitizeInternalPath('admissions-overview')).toBe(
+            '/admissions-overview'
+        );
+    });
+});

--- a/src/utils/authRedirect.ts
+++ b/src/utils/authRedirect.ts
@@ -1,0 +1,24 @@
+export const sanitizeInternalPath = (value: string | null): string | null => {
+    if (!value) {
+        return null;
+    }
+
+    if (
+        value.startsWith('//') ||
+        value.includes('://') ||
+        value.includes('\\')
+    ) {
+        return null;
+    }
+
+    return value.startsWith('/') ? value : `/${value}`;
+};
+
+export const getPostLoginRedirectPath = (
+    searchParams: URLSearchParams
+): string | null => {
+    return (
+        sanitizeInternalPath(searchParams.get('state')) ??
+        sanitizeInternalPath(searchParams.get('p'))
+    );
+};


### PR DESCRIPTION
This pull request improves the handling of post-login redirects, especially for Google OAuth authentication, by introducing a safer and more consistent mechanism for determining redirect destinations. It adds a utility for sanitizing internal redirect paths, updates the OAuth flow to use these utilities, and includes comprehensive tests to ensure correct and secure redirect behavior.

**Authentication Redirect Improvements:**

* Added `sanitizeInternalPath` and `getPostLoginRedirectPath` utilities in `src/utils/authRedirect.ts` to ensure redirect paths are safe and always internal, normalizing them as needed. 
* Updated the Google OAuth callback to use the new utility for determining the post-login redirect path, falling back to the dashboard if none is provided. 
* Modified the main app routing logic (`src/App.tsx`) to use `getPostLoginRedirectPath` for redirecting authenticated users, and to properly handle the OAuth callback route. 

**Google OAuth Flow Enhancements:**

* Updated the Google sign-in button (`src/components/Buttons/GoolgeSignInButton.tsx`) to use the new sanitization utility when constructing the OAuth state parameter, ensuring only valid internal paths are used for post-login redirection.

**Testing and Validation:**

* Added comprehensive tests for the new redirect utilities in `src/utils/authRedirect.test.ts`, covering prioritization of redirect parameters, path normalization, and rejection of unsafe paths. 